### PR TITLE
fixes ansi color code when output to html

### DIFF
--- a/cdiff.py
+++ b/cdiff.py
@@ -458,10 +458,10 @@ class DiffMarker(object):
 
             while text and count < width:
                 if text.startswith('\x00-'):    # del
-                    out.append(COLORS['reverse'] + COLORS[base_color])
+                    out.append(COLORS['reverse'])
                     text = text[2:]
                 elif text.startswith('\x00+'):  # add
-                    out.append(COLORS['reverse'] + COLORS[base_color])
+                    out.append(COLORS['reverse'])
                     text = text[2:]
                 elif text.startswith('\x00^'):  # change
                     out.append(COLORS['underline'] + COLORS[base_color])


### PR DESCRIPTION
This addresses issue #47, switching the output from `ESC[31mESC[7mESC[31ma` to `ESC[31mESC[7ma` for 

    $ diff <(echo 'a') <(echo 'b') --unified | cdiff -s --color=always | aha


