### PR TITLE
Add 'force pager' option

### DIFF
--- a/cdiff.py
+++ b/cdiff.py
@@ -635,7 +635,11 @@ def markup_to_pager(stream, opts):
     pager_cmd = ['less']
     if not os.getenv('LESS'):
         # Args stolen from git source: github.com/git/git/blob/master/pager.c
-        pager_cmd.extend(['-FRSX', '--shift 1'])
+        pager_cmd.extend(['-RSX', '--shift 1'])
+        if opts.force_pager:
+            pager_cmd.extend(['-+F'])
+        else:
+            pager_cmd.extend(['-F'])
     pager = subprocess.Popen(
         pager_cmd, stdin=subprocess.PIPE, stdout=sys.stdout)
 
@@ -751,6 +755,9 @@ def main():
     parser.add_option(
         '-c', '--color', default='auto', metavar='M',
         help="""colorize mode 'auto' (default), 'always', or 'never'""")
+    parser.add_option(
+        '-p', '--force-pager', action='store_true',
+        help='forcedly send output to the pager')
 
     # Hack: use OptionGroup text for extra help message after option list
     option_group = OptionGroup(


### PR DESCRIPTION
Use case:
I use cdiff as a difftool. This is what I have in .gitconfig:
```
[diff]
	tool = cdiff
[difftool "cdiff"]
	cmd = cdiff -s -c always -w 0 \"$LOCAL\" \"$REMOTE\"
[difftool]
	prompt = false
```

The problem is when my diff consists of many files where I changed a few lines of code. The difftool will print that files NOT using the pager, but as **cat** would. So I have to scroll my terminal up to see the start of diff. This is caused by **less** feature when `-F` flag is passed to it.

This patch can allow me to use
```
[difftool "cdiff"]
	cmd = cdiff -s --force-pager -c always -w 0 \"$LOCAL\" \"$REMOTE\"
```
So the output of **difftool** will be always paged.